### PR TITLE
feat: COR-G 모델 및 데이터 Hugging Face Hub에서 로드하도록 수정

### DIFF
--- a/DEMO_PAGE/pages/page7_cor_model.py
+++ b/DEMO_PAGE/pages/page7_cor_model.py
@@ -1,7 +1,16 @@
+
+from huggingface_hub import hf_hub_download
+import numpy as np
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch
-import numpy as np
+
+# huggingface repo
+REPO_ID = "jihji/cor-g-yelp-model"
+SUBFOLDER = "yelp"
+
+def load_from_hub(filename):
+    return hf_hub_download(repo_id=REPO_ID, filename=filename, subfolder=SUBFOLDER, repo_type="model")
 
 class COR_G(nn.Module):
     """

--- a/DEMO_PAGE/pages/page7_cor_paper.py
+++ b/DEMO_PAGE/pages/page7_cor_paper.py
@@ -159,13 +159,9 @@ def render_tab_cor_agent():
 
         def generate_recommendation(user_id):
             # 경로 설정
-            # weight_path = "./data/page7_data_n_model/cor_g_weights.pth"
             weight_path = load_from_hub("cor_g_weights.pth")
 
             # 데이터 로드
-            # user_feat_tensor = torch.FloatTensor(np.load(os.path.join(base_path, "user_feature.npy")))
-            # item_feat_tensor = torch.FloatTensor(np.load(os.path.join(base_path, "item_feature.npy")))
-            # interaction_matrix = np.load(os.path.join(base_path, "training_list.npy"), allow_pickle=True)
             user_feat_tensor = torch.FloatTensor(np.load(load_from_hub("user_feature.npy")))
             item_feat_tensor = torch.FloatTensor(np.load(load_from_hub("item_feature.npy")))
             interaction_matrix = np.load(load_from_hub("training_list.npy"), allow_pickle=True)

--- a/DEMO_PAGE/pages/page7_cor_paper.py
+++ b/DEMO_PAGE/pages/page7_cor_paper.py
@@ -6,7 +6,13 @@ from dotenv import load_dotenv
 import gradio as gr
 from pages.page7_cor_model import COR_G
 from openai import OpenAI
+from huggingface_hub import hf_hub_download
 
+REPO_ID = "jihji/cor-g-yelp-model"
+SUBFOLDER = "yelp"
+
+def load_from_hub(filename):
+    return hf_hub_download(repo_id=REPO_ID, filename=filename, subfolder=SUBFOLDER, repo_type="model")
 
 ######################  1. 논문 소개 탭 ###################### 
 def render_tab_paper_summary():
@@ -153,13 +159,16 @@ def render_tab_cor_agent():
 
         def generate_recommendation(user_id):
             # 경로 설정
-            base_path = "./data/page7_data_n_model/yelp/"
-            weight_path = "./data/page7_data_n_model/cor_g_weights.pth"
+            # weight_path = "./data/page7_data_n_model/cor_g_weights.pth"
+            weight_path = load_from_hub("cor_g_weights.pth")
 
             # 데이터 로드
-            user_feat_tensor = torch.FloatTensor(np.load(os.path.join(base_path, "user_feature.npy")))
-            item_feat_tensor = torch.FloatTensor(np.load(os.path.join(base_path, "item_feature.npy")))
-            interaction_matrix = np.load(os.path.join(base_path, "training_list.npy"), allow_pickle=True)
+            # user_feat_tensor = torch.FloatTensor(np.load(os.path.join(base_path, "user_feature.npy")))
+            # item_feat_tensor = torch.FloatTensor(np.load(os.path.join(base_path, "item_feature.npy")))
+            # interaction_matrix = np.load(os.path.join(base_path, "training_list.npy"), allow_pickle=True)
+            user_feat_tensor = torch.FloatTensor(np.load(load_from_hub("user_feature.npy")))
+            item_feat_tensor = torch.FloatTensor(np.load(load_from_hub("item_feature.npy")))
+            interaction_matrix = np.load(load_from_hub("training_list.npy"), allow_pickle=True)
 
             # Sparse interaction matrix
             n_users = user_feat_tensor.shape[0]


### PR DESCRIPTION
## 변경 내용

- 기존에는 `.pth`, `.npy` 모델 가중치 및 feature 파일을 로컬에 저장하고 불러오는 방식이었으나,
  GitHub 대용량 파일 제한으로 인해 Hugging Face Hub에서 직접 로드하는 방식으로 변경했습니다.
- Hugging Face Hub: https://huggingface.co/jihji/cor-g-yelp-model

## 주요 수정 파일

- `pages/page7_cor_model.py`: 모델 및 feature 파일을 `hf_hub_download`를 통해 로드하도록 수정
- `pages/page7_cor_paper.py`: 불필요한 코드 제거 및 데이터 경로 처리 로직 정리